### PR TITLE
Fix Typo in Documentation: "commited" to "committed" in add-ops.mdx

### DIFF
--- a/docs/contribute/add-ops.mdx
+++ b/docs/contribute/add-ops.mdx
@@ -98,7 +98,7 @@ You'll also need to implement the `trace_evaluation` method on `AddTraceTable`, 
 
 ```rust
 impl AddTraceTable {
-    /// Transforms the [`AddTraceTable`] into [`TraceEval`] to be commited
+    /// Transforms the [`AddTraceTable`] into [`TraceEval`] to be committed
     /// when generating a STARK proof.
     pub fn trace_evaluation(&self) -> Result<(TraceEval, AddClaim), TraceError> {
         let n_rows = self.table.len();


### PR DESCRIPTION


**Description:**  
This pull request corrects a typo in the documentation file `add-ops.mdx`, changing "commited" to the correct spelling "committed" in the comment describing the `AddTraceTable` transformation. No functional code changes were made; this update is purely for documentation clarity and accuracy.
