### PR TITLE
Add beginner-friendly instructions for running examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+### Running Examples for Beginners
+If you’re new to Rust or Git, follow these steps to get started easily:
+
+1. Install Rust: https://www.rust-lang.org/tools/install
+2. Clone the repo:
+   git clone https://github.com/ragefye/LuminAIR.git
+3. Navigate into the repo folder:
+   cd LuminAIR
+4. Run a simple example:
+   cargo run --example hello_world
+5. Explore other examples in the examples/ folder   
 
 ## 📖 Documentation
 


### PR DESCRIPTION

Pull Request type:
	•	Bugfix
	•	Feature
	•	Code style update (formatting, renaming)
	•	Refactoring (no functional changes, no API changes)
	•	Build-related changes
	•	Documentation content changes
	•	Other (please describe):

What is the current behavior?
New users need to manually figure out how to run Rust examples in the repo. The README lacks beginner-friendly guidance.

What is the new behavior?
	•	Added a “Running Examples for Beginners” section under Quick Start.
	•	Provides step-by-step instructions to install Rust, clone the repo, navigate folders, and run a simple example (hello_world.rs).
	•	Includes guidance for exploring other examples in the examples/ folder.

Does this introduce a breaking change?
	•	No

Other information
This change only affects documentation. No code is modified. It helps onboard new contributors and users more easily.